### PR TITLE
Allow for error page handling.

### DIFF
--- a/lib/capybara/driver/mechanize_driver.rb
+++ b/lib/capybara/driver/mechanize_driver.rb
@@ -144,8 +144,13 @@ class Capybara::Driver::Mechanize < Capybara::Driver::RackTest
       end
       
       reset_cache
-      @agent.send *( [method, url] + options)
-        
+      #In order to appropriately capture pages from which mechanize throws an exception
+      begin
+        @agent.send *( [method, url] + options)
+      rescue Exception => e
+        @agent.history.push(e.page)
+      end        
+
       @last_request_remote = true
     end
   end


### PR DESCRIPTION
Added code to appropriately capture pages to which Mechanize throws an exception.  For example, 401 Unauthorized pages.  
