### PR TITLE
Upgrade to Mechanize 2.0

### DIFF
--- a/capybara-mechanize.gemspec
+++ b/capybara-mechanize.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.7}
   
-  s.add_runtime_dependency(%q<mechanize>, ["~> 1.0.0"])
+  s.add_runtime_dependency(%q<mechanize>, ["~> 2.0.0"])
   s.add_runtime_dependency(%q<capybara>, ["~> 1.0.0"])
 end
 


### PR DESCRIPTION
Mechanize 2.0 release notes: http://blog.segment7.net/2011/06/27/mechanize-2-0

All capybara-mechanize tests pass with this change. I can imagine wanting to bump the version of capybara-mechanize as well, but I'll leave that to you guys.
