### PR TITLE
Upgrade to Capybara 1.1.0

### DIFF
--- a/capybara-mechanize.gemspec
+++ b/capybara-mechanize.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.3.7}
   
   s.add_runtime_dependency(%q<mechanize>, ["~> 2.0.0"])
-  s.add_runtime_dependency(%q<capybara>, ["~> 1.0.0"])
+  s.add_runtime_dependency(%q<capybara>, ["~> 1.1.0"])
 end
 

--- a/lib/capybara/mechanize/browser.rb
+++ b/lib/capybara/mechanize/browser.rb
@@ -7,7 +7,7 @@ class Capybara::Mechanize::Browser < Capybara::RackTest::Browser
   def_delegator :agent, :scheme_handlers
   def_delegator :agent, :scheme_handlers=
   
-  def initialize(app, options)
+  def initialize(driver)
     @agent = ::Mechanize.new
     @agent.redirect_ok = false
 
@@ -80,7 +80,11 @@ class Capybara::Mechanize::Browser < Capybara::RackTest::Browser
     
       unless path.start_with?('/')
         folders = request_path.split('/')
-        path = (folders[0, folders.size - 1] << path).join('/')
+        if folders.empty?
+          path = '/' + path
+        else
+          path = (folders[0, folders.size - 1] << path).join('/')
+        end
       end
       path = current_host + path
     end

--- a/lib/capybara/mechanize/driver.rb
+++ b/lib/capybara/mechanize/driver.rb
@@ -15,7 +15,7 @@ class Capybara::Mechanize::Driver < Capybara::RackTest::Driver
   end
   
   def browser
-    @browser ||= Capybara::Mechanize::Browser.new(app, options)
+    @browser ||= Capybara::Mechanize::Browser.new(self)
   end
   
 end

--- a/spec/session/mechanize_spec.rb
+++ b/spec/session/mechanize_spec.rb
@@ -4,6 +4,7 @@ describe Capybara::Session do
   context 'with mechanize driver' do
     before do
       @session = Capybara::Session.new(:mechanize, TestApp)
+      @session.driver.options[:respect_data_method] = true
       Capybara.default_host = 'http://www.local.com'
     end
 

--- a/spec/session/remote_mechanize_spec.rb
+++ b/spec/session/remote_mechanize_spec.rb
@@ -13,6 +13,7 @@ describe Capybara::Session do
     
     before do      
       @session = Capybara::Session.new(:mechanize)
+      @session.driver.options[:respect_data_method] = true
     end
 
     describe '#driver' do


### PR DESCRIPTION
Capybara 1.1.0 release notes: https://groups.google.com/group/ruby-capybara/browse_thread/thread/d571a86c48f19099

All capybara-mechanize tests pass with this change. I had to fix a little bug in determine_path and manually enable the respect_data_method option for the driver in the tests per https://github.com/jnicklas/capybara/commit/0188693ced2fe3362e9433b20f49b4dbc7a0fdcd to get everything passing after changing the version.
