### PR TITLE
capybara-mechanize doesn't submit forms that contain hashes with arrays with hashes correctly

### DIFF
--- a/lib/capybara/spec/extended_test_app.rb
+++ b/lib/capybara/spec/extended_test_app.rb
@@ -13,6 +13,13 @@ class ExtendedTestApp < TestApp#< Sinatra::Base
       </form>}
   end
 
+  get '/form_with_fancy_params' do
+    %{<form action="/params" method="post">
+       <input id="cart_line_items__product_id" name="cart[line_items][][product_id]" value="2">
+       <input type="submit" value="submit" />
+      </form>}
+  end
+
   get '/request_info/form_with_no_action' do
     %{<form method="post">
        <input type="submit" value="submit" />
@@ -31,6 +38,22 @@ class ExtendedTestApp < TestApp#< Sinatra::Base
     current_request_info
   end
 
+  post '/params' do
+    begin
+      # The problem is the form is posted like:
+      # {"cart"=>{"line_items"=>"[{\"product_id\"=>\"2\"}]"}}
+      # Note that the array is wrapped in a string.
+      # I couldn't get this to happen in the mechanize
+      # project, so I'm assuming it's a capybara bug.
+      puts params
+      "first product id is #{ params["cart"]["line_items"].first["product_id"] }"
+    rescue
+      puts $!.message
+      puts $!.backtrace
+      raise
+    end
+  end
+
   post '/request_info/*' do
     current_request_info
   end
@@ -42,4 +65,3 @@ class ExtendedTestApp < TestApp#< Sinatra::Base
       "Current host is #{request.url}, method #{request.request_method.downcase}"
     end
 end
-

--- a/spec/session/mechanize_spec.rb
+++ b/spec/session/mechanize_spec.rb
@@ -40,6 +40,13 @@ describe Capybara::Session do
       @session.body.should include("Current host is #{REMOTE_TEST_URL}/request_info/host, method post")
     end
 
+    it "should post fancy params correctly" do
+      @session.visit("#{REMOTE_TEST_URL}/form_with_fancy_params")
+      @session.click_button "submit"
+      params["cart"]["line_items"].should == [{"product_id" => "2"}]
+      @session.body.should include("first product id is 2")
+    end
+
     it "should use the last url when submitting a form with no action" do
       @session.visit("#{REMOTE_TEST_URL}/request_info/form_with_no_action")
       @session.click_button "submit"


### PR DESCRIPTION
This input is not handled correctly:

<pre>
&lt;input id="cart_line_items__product_id" name="cart[line_items][][product_id]" value="2">
</pre>


This is how the form is submitted:

<pre>
{"cart"=>{"line_items"=>"[{\"product_id\"=>\"2\"}]"}}
</pre>


Note that the array is wrapped in a string.
