### PR TITLE
reinstate a graceful reset rather than fall through to racktest

### DIFF
--- a/lib/capybara/mechanize/driver.rb
+++ b/lib/capybara/mechanize/driver.rb
@@ -18,4 +18,9 @@ class Capybara::Mechanize::Driver < Capybara::RackTest::Driver
     @browser ||= Capybara::Mechanize::Browser.new(self)
   end
   
+  def reset!
+    browser.agent.cookie_jar.clear!
+    browser.reset_host!
+  end
+
 end


### PR DESCRIPTION
Having upgraded to 3.x (and therefore Capybara 1.x and Mechanize 2.x) I noticed that my mechanize browser agent instance was getting re instantiated after every scenario when using Cucumber.

This is because there is no longer a reset! method in Capybara::Mechanize::Driver it simply falls through to Rack::Test which does the following:

```
def reset!
  @browser = nil
end
```

Can we revive what was done in 2.7 and have a more graceful rest, cleaning cookies and resetting remote host.

The reason for this is that it enables us to do a one time setup of browser instance settings such as proxy, ssl settings etc...otherwise these get cleared out on every scenario.

Note: I can see the logic for going with wiping the browser instance...as we don't have the overhead of restarting a headed browser.  But it does make it a pain to set up 'browser' level configuration on Mechanize.
