### PR TITLE
Upgrade to Mechanize 2.1

### DIFF
--- a/capybara-mechanize.gemspec
+++ b/capybara-mechanize.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.7}
   
-  s.add_runtime_dependency(%q<mechanize>, ["~> 2.0.0"])
+  s.add_runtime_dependency(%q<mechanize>, ["~> 2.1.0"])
   s.add_runtime_dependency(%q<capybara>, ["~> 1.1.0"])
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,4 +31,20 @@ RSpec.configure do |config|
   # config.filter_run :focus => true
 end
 
+class Net::HTTP::Persistent
+  # Mechanize 2.1 started using the net-http-persistent gem to support persistent (much faster)
+  # HTTP connections.  The gem has method to switch between either using Net::HTTP or
+  # Net::HTTP::Persistent::SSLReuse.
+  #
+  # Net::HTTP::Persistent::SSLReuse is not overwritten by the Artifice gem.
+  #
+  # This rewrite of Net::HTTP::Persistent rewrites a the method inside:
+  #
+  #     /net-http-persistent/lib/net/http/persistent.rb
+  #
+  def http_class # :nodoc:
+    Net::HTTP
+  end
+end
+
 REMOTE_TEST_URL = "http://localhost"


### PR DESCRIPTION
Hi there guys,

Just did some work to upgrade to use Mechanize 2.1

Needed to do the monkey patch as Mechanize 2.1 uses their net-http-persistent gem which bypasses Artifice.

Seemed to be the simplest way to do it as there is no direct way to set the instance variable required in Net::HTTP::Persistent#http_class that I could see.

All tests pass.

Mikel
