### PR TITLE
Replace post_data with Mechanize form

### DIFF
--- a/lib/capybara/mechanize/form.rb
+++ b/lib/capybara/mechanize/form.rb
@@ -1,0 +1,52 @@
+class Capybara::Mechanize::Form < Capybara::RackTest::Form
+  private
+
+  def params(button)
+    if !use_mechanize?
+      return super
+    end
+
+    node = {}
+    # Create a fake form
+    class << node
+      def search(*args); []; end
+    end
+    node['method'] = 'POST'
+    node['enctype'] = 'application/x-www-form-urlencoded'
+
+    @m_form = Mechanize::Form.new(node)
+
+    super
+
+    @m_form
+  end
+
+  def merge_param!(params, key, value)
+    if !use_mechanize?
+      return super
+    end
+
+    if value.is_a? NilUploadedFile
+      value = nil
+    end
+
+    if value.is_a? Rack::Test::UploadedFile
+      @m_form.enctype = 'multipart/form-data'
+
+      ul = Mechanize::Form::FileUpload.new({'name' => key.to_s}, value.original_filename)
+      ul.file_data = value.read
+
+      @m_form.file_uploads << ul
+
+      return params
+    end
+
+    @m_form.fields << Mechanize::Form::Field.new({'name' => key.to_s}, value)
+
+    params
+  end
+
+  def use_mechanize?
+    driver.remote?(native['action'].to_s) && method == :post
+  end
+end

--- a/lib/capybara/mechanize/node.rb
+++ b/lib/capybara/mechanize/node.rb
@@ -1,0 +1,10 @@
+class Capybara::Mechanize::Node < Capybara::RackTest::Node
+  def click
+    if tag_name == 'a'
+      super
+    elsif (tag_name == 'input' and %w(submit image).include?(type)) or
+        ((tag_name == 'button') and type.nil? or type == "submit")
+      Capybara::Mechanize::Form.new(driver, form).submit(self)
+    end
+  end
+end

--- a/spec/driver/remote_mechanize_driver_spec.rb
+++ b/spec/driver/remote_mechanize_driver_spec.rb
@@ -30,24 +30,6 @@ describe Capybara::Mechanize::Driver do
       @driver.body.should include('success')
     end
 
-    context "for a post request" do
-
-      it "should transform nested map in post data" do
-        @driver.post("#{REMOTE_TEST_URL}/form", {:form => {:key => "value"}})
-        @driver.body.should include('key: value')
-      end
-
-    end
-
-    context "process remote request" do
-
-      it "should transform nested map in post data" do
-        @driver.submit(:post, "#{REMOTE_TEST_URL}/form", {:form => {:key => "value"}})
-        @driver.body.should include('key: value')
-      end
-
-    end
-
     describe "redirect" do
       it "should handle redirects with http-params" do
         @driver.visit "#{REMOTE_TEST_URL}/redirect_with_http_param"


### PR DESCRIPTION
This is an attempt to fix our issues (#25, #26) with 'fancy' post params by skipping the Rack processing via normalize_params and instead build a Mechanize::Form object and submit it.
