### PR TITLE
Update call to Mechanize actions.

### DIFF
--- a/lib/capybara/mechanize/browser.rb
+++ b/lib/capybara/mechanize/browser.rb
@@ -169,10 +169,7 @@ class Capybara::Mechanize::Browser < Capybara::RackTest::Browser
 
       reset_cache!
       begin
-        args = []
-        args << attributes unless attributes.empty?
-        args << headers unless headers.empty?
-        @agent.send(method, url, *args)
+        @agent.send(method, url, attributes, headers)
       rescue => e
         raise "Received the following error for a #{method.to_s.upcase} request to #{url}: '#{e.message}'"
       end


### PR DESCRIPTION
While working with the code, I noticed that we're squashing together the action (get, post, etc) parameters and the action headers.  The corresponding mechanize methods expect these are separate parameters.

This pull request is to ask if there's a reason why we're passing headers as parameters/attributes instead of as headers.
