### PR TITLE
Capybara 2.1 - initial support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,13 @@ source 'http://rubygems.org'
 
 gemspec
 
+gem 'capybara', '2.1.0.rc1'
 gem 'rspec', '~> 2.12.0'
-gem "sinatra", "~> 1.3.3"
-gem "rake", "~> 10.0.3"
+gem 'sinatra', '~> 1.3.3'
+gem 'rake', '~> 10.0.3'
 gem 'rdoc'
 
 group :development do
-  gem "ruby-debug",   :platforms => :ruby_18
-  gem "debugger", :platforms => :ruby_19
+  gem 'ruby-debug',   :platforms => :ruby_18
+  gem 'debugger', :platforms => :ruby_19
 end

--- a/lib/capybara/mechanize/browser.rb
+++ b/lib/capybara/mechanize/browser.rb
@@ -63,8 +63,12 @@ class Capybara::Mechanize::Browser < Capybara::RackTest::Browser
     end
   end
 
-  def find(selector)
-    dom.xpath(selector).map { |node| Capybara::Mechanize::Node.new(self, node) }
+  def find(format, selector)
+    if format==:css
+      dom.css(selector, Capybara::RackTest::CSSHandlers.new)
+    else
+      dom.xpath(selector)
+    end.map { |node| Capybara::Mechanize::Node.new(self, node) }
   end
 
   attr_reader :agent

--- a/spec/driver/mechanize_driver_spec.rb
+++ b/spec/driver/mechanize_driver_spec.rb
@@ -13,14 +13,14 @@ describe Capybara::Mechanize::Driver, 'local' do
     it 'should keep headers on link clicks' do
       driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       driver.visit('/header_links')
-      driver.find('.//a').first.click
+      driver.find_xpath('.//a').first.click
       driver.html.should include('foobar')
     end
 
     it 'should keep headers on form submit' do
       driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       driver.visit('/header_links')
-      driver.find('.//input').first.click
+      driver.find_xpath('.//input').first.click
       driver.html.should include('foobar')
     end
 

--- a/spec/session/mechanize_spec.rb
+++ b/spec/session/mechanize_spec.rb
@@ -9,7 +9,8 @@ Capybara::SpecHelper.run_specs TestSessions::Mechanize, "Mechanize", :skip => [
   :screenshot,
   :frames,
   :windows,
-  :server
+  :server,
+  :hover
 ]
 
 describe Capybara::Session do

--- a/spec/session/remote_mechanize_spec.rb
+++ b/spec/session/remote_mechanize_spec.rb
@@ -19,7 +19,8 @@ session_describe = Capybara::SpecHelper.run_specs TestSessions::Mechanize, "Mech
   :screenshot,
   :frames,
   :windows,
-  :server
+  :server,
+  :hover
 ]
 
 session_describe.include_context("remote tests")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ Dir[File.join(PROJECT_ROOT, 'spec', 'support', '**', '*.rb')].each { |file| requ
 
 RSpec.configure do |config|
   # Spruce up the focus!
-  config.filter_run :focus => true
+  #config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
   config.treat_symbols_as_metadata_keys_with_true_values = true
 


### PR DESCRIPTION
Small changes for Capybara 2.1 compatibility. Only one test is failing which seems to be related to a difference in the way that mechanize and rack-test handle multiple checkbox elements in forms.
