### PR TITLE
Gemfile + Gemspec: remove too hard fixed gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,10 @@ source 'http://rubygems.org'
 
 gemspec
 
-gem 'rspec', '~> 2.99.0'
+gem 'rspec', '~> 2.99'
 gem 'launchy', '>= 2.0.4'
-gem 'sinatra', '~> 1.3.3'
-gem 'rake', '~> 10.0.3'
+gem 'sinatra', '~> 1.3'
+gem 'rake', '~> 10.0'
 gem 'rdoc'
 
 group :development do

--- a/capybara-mechanize.gemspec
+++ b/capybara-mechanize.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.7}
 
-  s.add_runtime_dependency(%q<mechanize>, ["~> 2.7.0"])
-  s.add_runtime_dependency(%q<capybara>, ["~> 2.4.4"])
+  s.add_runtime_dependency(%q<mechanize>, ["~> 2.7"])
+  s.add_runtime_dependency(%q<capybara>, ["~> 2.4"])
 end
 


### PR DESCRIPTION
When using with Poltergeist, there was a conflict due to too strong restrictions on gem version:

```
Bundler could not find compatible versions for gem "capybara":
  In Gemfile:
    poltergeist (~> 1.6) ruby depends on
      capybara (~> 2.1) ruby

    capybara-mechanize (~> 1.4) ruby depends on
      capybara (~> 2.4.4) ruby

    capybara (~> 2.5) ruby
```

I only remove the third number of gem version in Gemfile + Gemspecs.
