### PR TITLE
Rspec 3 - Ruby 2.3 - Style Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 sudo: false
-bundler_args: --without development
 before_install:
   - gem update --system
   - gem update bundler
@@ -9,6 +8,7 @@ before_install:
 rvm:
   - 2.3.7
   - 2.4.4
+  - 2.5.1
   - jruby
   - ruby-head
 gemfile:

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,8 @@
+# frozen_string_literal: true
+
 source 'http://rubygems.org'
 
 gemspec
 
 gem 'puma'
 gem 'sinatra', '~> 2.0'
-
-group :development do
-  gem 'debugger', platforms: :ruby_19
-end

--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,9 @@ source 'http://rubygems.org'
 
 gemspec
 
-gem 'rspec', '~> 3.0'
-gem 'launchy', '>= 2.0.4'
-gem 'sinatra', '~> 2.0'
-gem 'rake', '~> 10.0.3'
-gem 'rdoc'
 gem 'puma'
+gem 'sinatra', '~> 2.0'
 
 group :development do
-  gem 'debugger', :platforms => :ruby_19
+  gem 'debugger', platforms: :ruby_19
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,15 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec
 
 require 'rdoc/task'
 RDoc::Task.new do |rdoc|
-  version = File.exist?('VERSION') ? File.read('VERSION') : ""
+  version = File.exist?('VERSION') ? File.read('VERSION') : ''
 
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title = "capybara-mechanize #{version}"

--- a/capybara-mechanize.gemspec
+++ b/capybara-mechanize.gemspec
@@ -19,5 +19,9 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency(%q<mechanize>, ["~> 2.7.0"])
   s.add_runtime_dependency(%q<capybara>, [">= 2.4.4", "< 4"])
+  s.add_development_dependency(%q<rake>)
+  s.add_development_dependency(%q<rdoc>)
+  s.add_development_dependency(%q<rspec>, ["~>3.5"])
+  s.add_development_dependency(%q<launchy>, [">= 2.0.4"])
 end
 

--- a/capybara-mechanize.gemspec
+++ b/capybara-mechanize.gemspec
@@ -1,27 +1,30 @@
-$:.push File.expand_path("../lib", __FILE__)
-require "capybara/mechanize/version"
+# frozen_string_literal: true
+
+$:.push File.expand_path('lib', __dir__)
+require 'capybara/mechanize/version'
 
 Gem::Specification.new do |s|
-  s.name = %q{capybara-mechanize}
+  s.name = 'capybara-mechanize'
   s.version = Capybara::Mechanize::VERSION
+  s.required_ruby_version = '>= 2.3.0'
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Jeroen van Dijk"]
-  s.summary = %q{RackTest driver for Capybara with remote request support}
-  s.description = %q{RackTest driver for Capybara, but with remote request support thanks to mechanize}
+  s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
+  s.authors = ['Jeroen van Dijk']
+  s.summary = 'RackTest driver for Capybara with remote request support'
+  s.description = 'RackTest driver for Capybara, but with remote request support thanks to mechanize'
 
-  s.email = %q{jeroen@jeevidee.nl}
-  s.files = Dir.glob("{lib,spec}/**/*") + %w(README.mdown)
-  s.homepage = %q{https://github.com/jeroenvandijk/capybara-mechanize}
-  s.rdoc_options = ["--charset=UTF-8"]
-  s.require_paths = ["lib"]
-  s.rubygems_version = %q{1.3.7}
+  s.email = 'jeroen@jeevidee.nl'
+  s.files = Dir.glob('{lib,spec}/**/*') + %w[README.mdown]
+  s.homepage = 'https://github.com/jeroenvandijk/capybara-mechanize'
+  s.rdoc_options = ['--charset=UTF-8']
+  s.require_paths = ['lib']
+  s.rubygems_version = '1.3.7'
 
-  s.add_runtime_dependency(%q<mechanize>, ["~> 2.7.0"])
-  s.add_runtime_dependency(%q<capybara>, [">= 2.4.4", "< 4"])
-  s.add_development_dependency(%q<rake>)
-  s.add_development_dependency(%q<rdoc>)
-  s.add_development_dependency(%q<rspec>, ["~>3.5"])
-  s.add_development_dependency(%q<launchy>, [">= 2.0.4"])
+  s.add_runtime_dependency('capybara', ['>= 2.4.4', '< 4'])
+  s.add_runtime_dependency('mechanize', ['~> 2.7.0'])
+
+  s.add_development_dependency('launchy', ['>= 2.0.4'])
+  s.add_development_dependency('rake')
+  s.add_development_dependency('rdoc')
+  s.add_development_dependency('rspec', ['~>3.5'])
 end
-

--- a/gemfiles/Gemfile.capybara_2
+++ b/gemfiles/Gemfile.capybara_2
@@ -4,11 +4,9 @@ gemspec :path => '..'
 
 gem 'capybara', '~> 2.18.0'
 
-gem 'rspec', '~> 2.99.0'
-gem 'launchy', '>= 2.0.4'
 gem 'sinatra', '~> 1.3.3'
-gem 'rake', '~> 10.0.3'
-gem 'rdoc'
+
+gem 'nokogiri', '1.8.2' # 1.8.3+ fixes CSS selector escaping which causes two pending tests to pass
 
 group :development do
   gem 'ruby-debug',   :platforms => :ruby_18

--- a/gemfiles/Gemfile.capybara_2
+++ b/gemfiles/Gemfile.capybara_2
@@ -7,8 +7,3 @@ gem 'capybara', '~> 2.18.0'
 gem 'sinatra', '~> 1.3.3'
 
 gem 'nokogiri', '1.8.2' # 1.8.3+ fixes CSS selector escaping which causes two pending tests to pass
-
-group :development do
-  gem 'ruby-debug',   :platforms => :ruby_18
-  gem 'debugger', :platforms => :ruby_19
-end

--- a/gemfiles/Gemfile.capybara_master
+++ b/gemfiles/Gemfile.capybara_master
@@ -6,8 +6,3 @@ gem 'capybara', github: 'jnicklas/capybara'
 
 gem 'sinatra', '~> 2.0'
 gem 'puma'
-
-group :development do
-  gem 'ruby-debug',   :platforms => :ruby_18
-  gem 'debugger', :platforms => :ruby_19
-end

--- a/gemfiles/Gemfile.capybara_master
+++ b/gemfiles/Gemfile.capybara_master
@@ -4,11 +4,7 @@ gemspec :path => '..'
 
 gem 'capybara', github: 'jnicklas/capybara'
 
-gem 'rspec', '~> 3.0'
-gem 'launchy', '>= 2.0.4'
 gem 'sinatra', '~> 2.0'
-gem 'rake', '~> 10.0', '>= 10.0.3'
-gem 'rdoc'
 gem 'puma'
 
 group :development do

--- a/lib/capybara/mechanize.rb
+++ b/lib/capybara/mechanize.rb
@@ -1,19 +1,18 @@
+# frozen_string_literal: true
+
 require 'capybara'
 
 module Capybara::Mechanize
   class << self
-
     # Host that should be considered local (includes default_host)
     def local_hosts
       @local_hosts ||= begin
-        default_host = URI.parse(Capybara.default_host || "").host || Capybara.default_host
+        default_host = URI.parse(Capybara.default_host || '').host || Capybara.default_host
         [default_host].compact
       end
     end
 
-    def local_hosts=(hosts)
-      @local_hosts = hosts
-    end
+    attr_writer :local_hosts
   end
 end
 

--- a/lib/capybara/mechanize/cucumber.rb
+++ b/lib/capybara/mechanize/cucumber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'capybara/mechanize'
 
 Before('@mechanize') do

--- a/lib/capybara/mechanize/driver.rb
+++ b/lib/capybara/mechanize/driver.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
+
 require 'capybara/mechanize/browser'
 
 class Capybara::Mechanize::Driver < Capybara::RackTest::Driver
-
   def initialize(app, **options)
-    raise ArgumentError, "mechanize requires a rack application, but none was given" unless app
+    raise ArgumentError, 'mechanize requires a rack application, but none was given' unless app
 
     super
   end
@@ -12,7 +13,7 @@ class Capybara::Mechanize::Driver < Capybara::RackTest::Driver
     browser.remote?(url)
   end
 
-  def configure(&block)
+  def configure
     yield(browser.agent) if block_given?
   end
 

--- a/lib/capybara/mechanize/node.rb
+++ b/lib/capybara/mechanize/node.rb
@@ -1,18 +1,16 @@
+# frozen_string_literal: true
+
 class Capybara::Mechanize::Node < Capybara::RackTest::Node
   def click(keys = [], offset = {})
-    raise ArgumentError, "The mechanize driver does not support click options" unless keys.empty? && offset.empty?
+    raise ArgumentError, 'The mechanize driver does not support click options' unless keys.empty? && offset.empty?
 
     submits = respond_to?(:submits?) ? submits? :
-      ((tag_name == 'input' and %w(submit image).include?(type)) or
-        ((tag_name == 'button') and type.nil? or type == "submit"))
+      ((tag_name == 'input' and %w[submit image].include?(type)) or
+        ((tag_name == 'button') and type.nil? or type == 'submit'))
 
     if tag_name == 'a' or tag_name == 'label' or
-        (tag_name == 'input' and %w(checkbox radio).include?(type))
-      if Capybara::VERSION > '3.0.0'
-        super
-      else
-        super()
-      end
+        (tag_name == 'input' and %w[checkbox radio].include?(type))
+      Capybara::VERSION > '3.0.0' ? super : super()
     elsif submits
       associated_form = form
       Capybara::Mechanize::Form.new(driver, form).submit(self) if associated_form

--- a/lib/capybara/mechanize/version.rb
+++ b/lib/capybara/mechanize/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Capybara
   module Mechanize
     VERSION = '1.10.1'

--- a/lib/capybara/spec/extended_test_app.rb
+++ b/lib/capybara/spec/extended_test_app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'capybara/spec/test_app'
 
 class ExtendedTestApp < TestApp
@@ -9,19 +11,19 @@ class ExtendedTestApp < TestApp
   end
 
   get '/form_with_relative_action_to_host' do
-    %{<form action="/request_info/host" method="post">
+    %(<form action="/request_info/host" method="post">
        <input type="submit" value="submit" />
-      </form>}
+      </form>)
   end
 
   get '/request_info/form_with_no_action' do
-    %{<form method="post">
+    %(<form method="post">
        <input type="submit" value="submit" />
-      </form>}
+      </form>)
   end
 
   get '/relative_link_to_host' do
-    %{<a href="/request_info/host">host</a>}
+    %(<a href="/request_info/host">host</a>)
   end
 
   get '/request_info/user_agent' do
@@ -37,15 +39,15 @@ class ExtendedTestApp < TestApp
   end
 
   get '/subsite/relative_link_to_host' do
-    %{<a href="/subsite/request_info2/host">host</a>}
+    %(<a href="/subsite/request_info2/host">host</a>)
   end
 
   get '/subsite/local_link_to_host' do
-    %{<a href="request_info2/host">host</a>}
+    %(<a href="request_info2/host">host</a>)
   end
 
   get '/subsite/request_info2/*' do
-    "subsite: " + current_request_info
+    'subsite: ' + current_request_info
   end
 
   get '/redirect_with_http_param' do
@@ -53,25 +55,24 @@ class ExtendedTestApp < TestApp
   end
 
   get '/redirect_target' do
-    %{correct redirect}
+    %(correct redirect)
   end
 
   get %r{/form_posts_to/(.*)} do
-    %{
+    %(
       <form action="#{params[:captures].first}" method="post">
         <input type="submit" value="submit" />
       </form>
-    }
+    )
   end
 
   post '/get_referer' do
-    request.referer.nil? ? "No referer" : "Got referer: #{request.referer}"
+    request.referer.nil? ? 'No referer' : "Got referer: #{request.referer}"
   end
 
   private
 
-    def current_request_info
-      "Current host is #{request.url}, method #{request.request_method.downcase}"
-    end
+  def current_request_info
+    "Current host is #{request.url}, method #{request.request_method.downcase}"
+  end
 end
-

--- a/spec/driver/mechanize_driver_spec.rb
+++ b/spec/driver/mechanize_driver_spec.rb
@@ -1,47 +1,49 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Capybara::Mechanize::Driver, 'local' do
   let(:driver) { Capybara::Mechanize::Driver.new(ExtendedTestApp) }
 
-  describe "#configure" do
-    it "allows extended configuration of the agent" do
-      expect_any_instance_of(::Mechanize).to receive(:foo=).with("test")
+  describe '#configure' do
+    it 'allows extended configuration of the agent' do
+      expect_any_instance_of(::Mechanize).to receive(:foo=).with('test')
       driver.configure do |agent|
-        agent.foo = "test"
+        agent.foo = 'test'
       end
     end
   end
 
   describe ':headers option' do
     it 'should always set headers' do
-      driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
+      driver = Capybara::RackTest::Driver.new(TestApp, headers: { 'HTTP_FOO' => 'foobar' })
       driver.visit('/get_header')
       expect(driver.html).to include('foobar')
     end
 
     it 'should keep headers on link clicks' do
-      driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
+      driver = Capybara::RackTest::Driver.new(TestApp, headers: { 'HTTP_FOO' => 'foobar' })
       driver.visit('/header_links')
       driver.find_xpath('.//a').first.click
       expect(driver.html).to include('foobar')
     end
 
     it 'should keep headers on form submit' do
-      driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
+      driver = Capybara::RackTest::Driver.new(TestApp, headers: { 'HTTP_FOO' => 'foobar' })
       driver.visit('/header_links')
       driver.find_xpath('.//input').first.click
       expect(driver.html).to include('foobar')
     end
 
     it 'should keep headers on redirects' do
-      driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
+      driver = Capybara::RackTest::Driver.new(TestApp, headers: { 'HTTP_FOO' => 'foobar' })
       driver.visit('/get_header_via_redirect')
       expect(driver.html).to include('foobar')
     end
   end
 
   describe ':follow_redirects option' do
-    it "defaults to following redirects" do
+    it 'defaults to following redirects' do
       driver = Capybara::RackTest::Driver.new(TestApp)
 
       driver.visit('/redirect')
@@ -49,8 +51,8 @@ describe Capybara::Mechanize::Driver, 'local' do
       expect(driver.browser.current_url).to match %r{/landed$}
     end
 
-    it "is possible to not follow redirects" do
-      driver = Capybara::RackTest::Driver.new(TestApp, :follow_redirects => false)
+    it 'is possible to not follow redirects' do
+      driver = Capybara::RackTest::Driver.new(TestApp, follow_redirects: false)
 
       driver.visit('/redirect')
       expect(driver.response.header['Location']).to match %r{/redirect_again$}
@@ -59,46 +61,46 @@ describe Capybara::Mechanize::Driver, 'local' do
   end
 
   describe ':redirect_limit option' do
-    context "with default redirect limit" do
+    context 'with default redirect limit' do
       let(:driver) { Capybara::RackTest::Driver.new(TestApp) }
 
-      it "should follow 5 redirects" do
-        driver.visit("/redirect/5/times")
+      it 'should follow 5 redirects' do
+        driver.visit('/redirect/5/times')
         expect(driver.html).to include('redirection complete')
       end
 
-      it "should not follow more than 6 redirects" do
+      it 'should not follow more than 6 redirects' do
         expect do
-          driver.visit("/redirect/6/times")
+          driver.visit('/redirect/6/times')
         end.to raise_error(Capybara::InfiniteRedirectError)
       end
     end
 
-    context "with 21 redirect limit" do
-      let(:driver) { Capybara::RackTest::Driver.new(TestApp, :redirect_limit => 21) }
+    context 'with 21 redirect limit' do
+      let(:driver) { Capybara::RackTest::Driver.new(TestApp, redirect_limit: 21) }
 
-      it "should follow 21 redirects" do
-        driver.visit("/redirect/21/times")
+      it 'should follow 21 redirects' do
+        driver.visit('/redirect/21/times')
         expect(driver.html).to include('redirection complete')
       end
 
-      it "should not follow more than 21 redirects" do
+      it 'should not follow more than 21 redirects' do
         expect do
-          driver.visit("/redirect/22/times")
+          driver.visit('/redirect/22/times')
         end.to raise_error(Capybara::InfiniteRedirectError)
       end
     end
   end
 
-  it "should default to local mode for relative paths" do
+  it 'should default to local mode for relative paths' do
     expect(driver).not_to be_remote('/')
   end
 
-  it "should default to local mode for the default host" do
+  it 'should default to local mode for the default host' do
     expect(driver).not_to be_remote('http://www.example.com')
   end
 
-  context "with an app_host" do
+  context 'with an app_host' do
     before do
       Capybara.app_host = 'http://www.remote.com'
     end
@@ -107,12 +109,12 @@ describe Capybara::Mechanize::Driver, 'local' do
       Capybara.app_host = nil
     end
 
-    it "should treat urls as remote" do
+    it 'should treat urls as remote' do
       expect(driver).to be_remote('http://www.remote.com')
     end
   end
 
-  context "with a default url, no app host" do
+  context 'with a default url, no app host' do
     before do
       Capybara.default_host = 'http://www.local.com'
     end
@@ -121,7 +123,7 @@ describe Capybara::Mechanize::Driver, 'local' do
       Capybara.default_host = CAPYBARA_DEFAULT_HOST
     end
 
-    context "local hosts" do
+    context 'local hosts' do
       before do
         Capybara::Mechanize.local_hosts = ['subdomain.local.com']
       end
@@ -130,35 +132,35 @@ describe Capybara::Mechanize::Driver, 'local' do
         Capybara::Mechanize.local_hosts = nil
       end
 
-      it "should allow local hosts to be set" do
+      it 'should allow local hosts to be set' do
         expect(driver).not_to be_remote('http://subdomain.local.com')
       end
     end
 
-    it "should treat urls with the same host names as local" do
+    it 'should treat urls with the same host names as local' do
       expect(driver).not_to be_remote('http://www.local.com')
     end
 
-    it "should treat other urls as remote" do
+    it 'should treat other urls as remote' do
       expect(driver).to be_remote('http://www.remote.com')
     end
 
-    it "should treat relative paths as remote if the previous request was remote" do
+    it 'should treat relative paths as remote if the previous request was remote' do
       driver.visit(remote_test_url)
       expect(driver).to be_remote('/some_relative_link')
     end
 
-    it "should treat relative paths as local if the previous request was local" do
+    it 'should treat relative paths as local if the previous request was local' do
       driver.visit('http://www.local.com')
       expect(driver).not_to be_remote('/some_relative_link')
     end
 
-    it "should receive the right host" do
+    it 'should receive the right host' do
       driver.visit('http://www.local.com/host')
       should_be_a_local_get
     end
 
-    it "should consider relative paths to be local when the previous request was local" do
+    it 'should consider relative paths to be local when the previous request was local' do
       driver.visit('http://www.local.com/host')
       driver.visit('/host')
 
@@ -166,7 +168,7 @@ describe Capybara::Mechanize::Driver, 'local' do
       expect(driver).not_to be_remote('/first_local')
     end
 
-    it "should consider relative paths to be remote when the previous request was remote" do
+    it 'should consider relative paths to be remote when the previous request was remote' do
       driver.visit("#{remote_test_url}/host")
       driver.get('/host')
 
@@ -174,7 +176,7 @@ describe Capybara::Mechanize::Driver, 'local' do
       expect(driver).to be_remote('/second_remote')
     end
 
-    it "should always switch to the right context" do
+    it 'should always switch to the right context' do
       driver.visit('http://www.local.com/host')
       driver.get('/host')
       driver.get("#{remote_test_url}/host")
@@ -185,17 +187,17 @@ describe Capybara::Mechanize::Driver, 'local' do
       expect(driver).not_to be_remote('/second_local')
     end
 
-    it "should follow redirects from local to remote" do
+    it 'should follow redirects from local to remote' do
       driver.visit("http://www.local.com/redirect_to/#{remote_test_url}/host")
       should_be_a_remote_get
     end
 
-    it "should follow redirects from remote to local" do
+    it 'should follow redirects from remote to local' do
       driver.visit("#{remote_test_url}/redirect_to/http://www.local.com/host")
       should_be_a_local_get
     end
 
-    it "passes the status code of remote calls back to be validated" do
+    it 'passes the status code of remote calls back to be validated' do
       quietly do
         driver.visit(remote_test_url)
         driver.get('/asdfafadfsdfs')
@@ -203,23 +205,23 @@ describe Capybara::Mechanize::Driver, 'local' do
       end
     end
 
-    context "when errors are set to true" do
-      it "raises an useful error because it is probably a misconfiguration" do
+    context 'when errors are set to true' do
+      it 'raises an useful error because it is probably a misconfiguration' do
         quietly do
           original = Capybara.raise_server_errors
 
-          expect {
+          expect do
             driver.visit(remote_test_url)
             Capybara.raise_server_errors = true
             driver.get('/asdfafadfsdfs')
-          }.to raise_error(%r{Received the following error for a GET request to /asdfafadfsdfs:})
+          end.to raise_error(%r{Received the following error for a GET request to /asdfafadfsdfs:})
           Capybara.raise_server_errors = original
         end
       end
     end
   end
 
-  it "should include the right host when remote" do
+  it 'should include the right host when remote' do
     driver.visit("#{remote_test_url}/host")
     should_be_a_remote_get
   end
@@ -237,7 +239,7 @@ describe Capybara::Mechanize::Driver, 'local' do
       driver.visit("#{remote_test_url}/host")
       should_be_a_remote_get
       driver.reset!
-      driver.visit("/host")
+      driver.visit('/host')
       should_be_a_local_get
     end
   end
@@ -247,7 +249,6 @@ describe Capybara::Mechanize::Driver, 'local' do
   end
 
   def should_be_a_local_get
-    expect(driver.current_url).to include("www.local.com")
+    expect(driver.current_url).to include('www.local.com')
   end
-
 end

--- a/spec/driver/mechanize_driver_spec.rb
+++ b/spec/driver/mechanize_driver_spec.rb
@@ -5,7 +5,7 @@ describe Capybara::Mechanize::Driver, 'local' do
 
   describe "#configure" do
     it "allows extended configuration of the agent" do
-      ::Mechanize.any_instance.should_receive(:foo=).with("test")
+      expect_any_instance_of(::Mechanize).to receive(:foo=).with("test")
       driver.configure do |agent|
         agent.foo = "test"
       end
@@ -16,27 +16,27 @@ describe Capybara::Mechanize::Driver, 'local' do
     it 'should always set headers' do
       driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       driver.visit('/get_header')
-      driver.html.should include('foobar')
+      expect(driver.html).to include('foobar')
     end
 
     it 'should keep headers on link clicks' do
       driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       driver.visit('/header_links')
       driver.find_xpath('.//a').first.click
-      driver.html.should include('foobar')
+      expect(driver.html).to include('foobar')
     end
 
     it 'should keep headers on form submit' do
       driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       driver.visit('/header_links')
       driver.find_xpath('.//input').first.click
-      driver.html.should include('foobar')
+      expect(driver.html).to include('foobar')
     end
 
     it 'should keep headers on redirects' do
       driver = Capybara::RackTest::Driver.new(TestApp, :headers => {'HTTP_FOO' => 'foobar'})
       driver.visit('/get_header_via_redirect')
-      driver.html.should include('foobar')
+      expect(driver.html).to include('foobar')
     end
   end
 
@@ -45,16 +45,16 @@ describe Capybara::Mechanize::Driver, 'local' do
       driver = Capybara::RackTest::Driver.new(TestApp)
 
       driver.visit('/redirect')
-      driver.response.header['Location'].should be_nil
-      driver.browser.current_url.should match %r{/landed$}
+      expect(driver.response.header['Location']).to be_nil
+      expect(driver.browser.current_url).to match %r{/landed$}
     end
 
     it "is possible to not follow redirects" do
       driver = Capybara::RackTest::Driver.new(TestApp, :follow_redirects => false)
 
       driver.visit('/redirect')
-      driver.response.header['Location'].should match %r{/redirect_again$}
-      driver.browser.current_url.should match %r{/redirect$}
+      expect(driver.response.header['Location']).to match %r{/redirect_again$}
+      expect(driver.browser.current_url).to match %r{/redirect$}
     end
   end
 
@@ -64,7 +64,7 @@ describe Capybara::Mechanize::Driver, 'local' do
 
       it "should follow 5 redirects" do
         driver.visit("/redirect/5/times")
-        driver.html.should include('redirection complete')
+        expect(driver.html).to include('redirection complete')
       end
 
       it "should not follow more than 6 redirects" do
@@ -79,7 +79,7 @@ describe Capybara::Mechanize::Driver, 'local' do
 
       it "should follow 21 redirects" do
         driver.visit("/redirect/21/times")
-        driver.html.should include('redirection complete')
+        expect(driver.html).to include('redirection complete')
       end
 
       it "should not follow more than 21 redirects" do
@@ -91,11 +91,11 @@ describe Capybara::Mechanize::Driver, 'local' do
   end
 
   it "should default to local mode for relative paths" do
-    driver.should_not be_remote('/')
+    expect(driver).not_to be_remote('/')
   end
 
   it "should default to local mode for the default host" do
-    driver.should_not be_remote('http://www.example.com')
+    expect(driver).not_to be_remote('http://www.example.com')
   end
 
   context "with an app_host" do
@@ -108,7 +108,7 @@ describe Capybara::Mechanize::Driver, 'local' do
     end
 
     it "should treat urls as remote" do
-      driver.should be_remote('http://www.remote.com')
+      expect(driver).to be_remote('http://www.remote.com')
     end
   end
 
@@ -131,26 +131,26 @@ describe Capybara::Mechanize::Driver, 'local' do
       end
 
       it "should allow local hosts to be set" do
-        driver.should_not be_remote('http://subdomain.local.com')
+        expect(driver).not_to be_remote('http://subdomain.local.com')
       end
     end
 
     it "should treat urls with the same host names as local" do
-      driver.should_not be_remote('http://www.local.com')
+      expect(driver).not_to be_remote('http://www.local.com')
     end
 
     it "should treat other urls as remote" do
-      driver.should be_remote('http://www.remote.com')
+      expect(driver).to be_remote('http://www.remote.com')
     end
 
     it "should treat relative paths as remote if the previous request was remote" do
       driver.visit(remote_test_url)
-      driver.should be_remote('/some_relative_link')
+      expect(driver).to be_remote('/some_relative_link')
     end
 
     it "should treat relative paths as local if the previous request was local" do
       driver.visit('http://www.local.com')
-      driver.should_not be_remote('/some_relative_link')
+      expect(driver).not_to be_remote('/some_relative_link')
     end
 
     it "should receive the right host" do
@@ -163,7 +163,7 @@ describe Capybara::Mechanize::Driver, 'local' do
       driver.visit('/host')
 
       should_be_a_local_get
-      driver.should_not be_remote('/first_local')
+      expect(driver).not_to be_remote('/first_local')
     end
 
     it "should consider relative paths to be remote when the previous request was remote" do
@@ -171,7 +171,7 @@ describe Capybara::Mechanize::Driver, 'local' do
       driver.get('/host')
 
       should_be_a_remote_get
-      driver.should be_remote('/second_remote')
+      expect(driver).to be_remote('/second_remote')
     end
 
     it "should always switch to the right context" do
@@ -182,7 +182,7 @@ describe Capybara::Mechanize::Driver, 'local' do
       driver.get('http://www.local.com/host')
 
       should_be_a_local_get
-      driver.should_not be_remote('/second_local')
+      expect(driver).not_to be_remote('/second_local')
     end
 
     it "should follow redirects from local to remote" do
@@ -199,7 +199,7 @@ describe Capybara::Mechanize::Driver, 'local' do
       quietly do
         driver.visit(remote_test_url)
         driver.get('/asdfafadfsdfs')
-        driver.response.status.should be >= 400
+        expect(driver.response.status).to be >= 400
       end
     end
 
@@ -243,11 +243,11 @@ describe Capybara::Mechanize::Driver, 'local' do
   end
 
   def should_be_a_remote_get
-    driver.current_url.should include(remote_test_url)
+    expect(driver.current_url).to include(remote_test_url)
   end
 
   def should_be_a_local_get
-    driver.current_url.should include("www.local.com")
+    expect(driver.current_url).to include("www.local.com")
   end
 
 end

--- a/spec/driver/remote_mechanize_driver_spec.rb
+++ b/spec/driver/remote_mechanize_driver_spec.rb
@@ -14,32 +14,32 @@ describe Capybara::Mechanize::Driver, 'remote' do
   context "in remote mode" do
     it "should pass arguments through to a get request" do
       driver.visit("#{remote_test_url}/form/get", {:form => {:value => "success"}})
-      driver.html.should include('success')
+      expect(driver.html).to include('success')
     end
 
     it "should pass arguments through to a post request" do
       driver.post("#{remote_test_url}/form", {:form => {:value => "success"}})
-      driver.html.should include('success')
+      expect(driver.html).to include('success')
     end
 
     describe "redirect" do
       it "should handle redirects with http-params" do
         driver.visit "#{remote_test_url}/redirect_with_http_param"
-        driver.html.should include('correct redirect')
+        expect(driver.html).to include('correct redirect')
       end
     end
 
     context "for a post request" do
       it 'transforms nested map in post data' do
         driver.post("#{remote_test_url}/form", {:form => {:key => 'value'}})
-        driver.html.should match(/:key=>"value"|key: value/)
+        expect(driver.html).to match(/:key=>"value"|key: value/)
       end
     end
 
     context 'process remote request' do
       it 'transforms nested map in post data' do
         driver.submit(:post, "#{remote_test_url}/form", {:form => {:key => 'value'}})
-        driver.html.should match(/:key=>"value"|key: value/)
+        expect(driver.html).to match(/:key=>"value"|key: value/)
       end
     end
   end

--- a/spec/driver/remote_mechanize_driver_spec.rb
+++ b/spec/driver/remote_mechanize_driver_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Capybara::Mechanize::Driver, 'remote' do
@@ -11,34 +13,34 @@ describe Capybara::Mechanize::Driver, 'remote' do
 
   let(:driver) { Capybara::Mechanize::Driver.new(ExtendedTestApp) }
 
-  context "in remote mode" do
-    it "should pass arguments through to a get request" do
-      driver.visit("#{remote_test_url}/form/get", {:form => {:value => "success"}})
+  context 'in remote mode' do
+    it 'should pass arguments through to a get request' do
+      driver.visit("#{remote_test_url}/form/get", form: { value: 'success' })
       expect(driver.html).to include('success')
     end
 
-    it "should pass arguments through to a post request" do
-      driver.post("#{remote_test_url}/form", {:form => {:value => "success"}})
+    it 'should pass arguments through to a post request' do
+      driver.post("#{remote_test_url}/form", form: { value: 'success' })
       expect(driver.html).to include('success')
     end
 
-    describe "redirect" do
-      it "should handle redirects with http-params" do
+    describe 'redirect' do
+      it 'should handle redirects with http-params' do
         driver.visit "#{remote_test_url}/redirect_with_http_param"
         expect(driver.html).to include('correct redirect')
       end
     end
 
-    context "for a post request" do
+    context 'for a post request' do
       it 'transforms nested map in post data' do
-        driver.post("#{remote_test_url}/form", {:form => {:key => 'value'}})
+        driver.post("#{remote_test_url}/form", form: { key: 'value' })
         expect(driver.html).to match(/:key=>"value"|key: value/)
       end
     end
 
     context 'process remote request' do
       it 'transforms nested map in post data' do
-        driver.submit(:post, "#{remote_test_url}/form", {:form => {:key => 'value'}})
+        driver.submit(:post, "#{remote_test_url}/form", form: { key: 'value' })
         expect(driver.html).to match(/:key=>"value"|key: value/)
       end
     end

--- a/spec/session/mechanize_spec.rb
+++ b/spec/session/mechanize_spec.rb
@@ -1,21 +1,23 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module TestSessions
   Mechanize = Capybara::Session.new(:mechanize, TestApp)
 end
 
-Capybara::SpecHelper.run_specs TestSessions::Mechanize, "Mechanize", :capybara_skip => [
-  :js,
-  :screenshot,
-  :frames,
-  :windows,
-  :server,
-  :hover,
-  :modals,
-  :about_scheme,
-  :send_keys,
-  :css,
-  :download
+Capybara::SpecHelper.run_specs TestSessions::Mechanize, 'Mechanize', capybara_skip: %i[
+  js
+  screenshot
+  frames
+  windows
+  server
+  hover
+  modals
+  about_scheme
+  send_keys
+  css
+  download
 ]
 
 describe Capybara::Session do
@@ -31,36 +33,36 @@ describe Capybara::Session do
     end
 
     describe '#driver' do
-      it "should be a mechanize driver" do
+      it 'should be a mechanize driver' do
         expect(session.driver).to be_an_instance_of(Capybara::Mechanize::Driver)
       end
     end
 
     describe '#mode' do
-      it "should remember the mode" do
+      it 'should remember the mode' do
         expect(session.mode).to eq(:mechanize)
       end
     end
 
     describe '#click_link' do
-      it "should use data-method if option is true" do
+      it 'should use data-method if option is true' do
         session.driver.options[:respect_data_method] = true
-        session.visit "/with_html"
-        session.click_link "A link with data-method"
+        session.visit '/with_html'
+        session.click_link 'A link with data-method'
         expect(session.html).to include('The requested object was deleted')
       end
 
-      it "should not use data-method if option is false" do
+      it 'should not use data-method if option is false' do
         session.driver.options[:respect_data_method] = false
-        session.visit "/with_html"
-        session.click_link "A link with data-method"
+        session.visit '/with_html'
+        session.click_link 'A link with data-method'
         expect(session.html).to include('Not deleted')
       end
 
       it "should use data-method if available even if it's capitalized" do
         session.driver.options[:respect_data_method] = true
-        session.visit "/with_html"
-        session.click_link "A link with capitalized data-method"
+        session.visit '/with_html'
+        session.click_link 'A link with capitalized data-method'
         expect(session.html).to include('The requested object was deleted')
       end
 
@@ -69,37 +71,37 @@ describe Capybara::Session do
       end
     end
 
-    describe "#attach_file" do
-      context "with multipart form" do
-        it "should submit an empty form-data section if no file is submitted" do
-          session.visit("/form")
-          session.click_button("Upload Empty")
+    describe '#attach_file' do
+      context 'with multipart form' do
+        it 'should submit an empty form-data section if no file is submitted' do
+          session.visit('/form')
+          session.click_button('Upload Empty')
           expect(session.html).to include('Successfully ignored empty file field.')
         end
       end
     end
 
-    it "should use the last remote url when following relative links" do
+    it 'should use the last remote url when following relative links' do
       session.visit("#{remote_test_url}/relative_link_to_host")
-      session.click_link "host"
+      session.click_link 'host'
       expect(session.body).to include("Current host is #{remote_test_url}/request_info/host, method get")
     end
 
-    it "should use the last remote url when submitting a form with a relative action" do
+    it 'should use the last remote url when submitting a form with a relative action' do
       session.visit("#{remote_test_url}/form_with_relative_action_to_host")
-      session.click_button "submit"
+      session.click_button 'submit'
       expect(session.body).to include("Current host is #{remote_test_url}/request_info/host, method post")
     end
 
-    it "should use the last url when submitting a form with no action" do
+    it 'should use the last url when submitting a form with no action' do
       session.visit("#{remote_test_url}/request_info/form_with_no_action")
-      session.click_button "submit"
+      session.click_button 'submit'
       expect(session.body).to include("Current host is #{remote_test_url}/request_info/form_with_no_action, method post")
     end
 
-    it "should send correct user agent" do
+    it 'should send correct user agent' do
       session.visit("#{remote_test_url}/request_info/user_agent")
-      expect(session.body).to include("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_0) AppleWebKit/535.2 (KHTML, like Gecko) Chrome/15.0.853.0 Safari/535.2")
+      expect(session.body).to include('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_0) AppleWebKit/535.2 (KHTML, like Gecko) Chrome/15.0.853.0 Safari/535.2')
     end
 
     context 'form referer when switching from local to remote' do

--- a/spec/session/mechanize_spec.rb
+++ b/spec/session/mechanize_spec.rb
@@ -32,13 +32,13 @@ describe Capybara::Session do
 
     describe '#driver' do
       it "should be a mechanize driver" do
-        session.driver.should be_an_instance_of(Capybara::Mechanize::Driver)
+        expect(session.driver).to be_an_instance_of(Capybara::Mechanize::Driver)
       end
     end
 
     describe '#mode' do
       it "should remember the mode" do
-        session.mode.should == :mechanize
+        expect(session.mode).to eq(:mechanize)
       end
     end
 
@@ -47,21 +47,21 @@ describe Capybara::Session do
         session.driver.options[:respect_data_method] = true
         session.visit "/with_html"
         session.click_link "A link with data-method"
-        session.html.should include('The requested object was deleted')
+        expect(session.html).to include('The requested object was deleted')
       end
 
       it "should not use data-method if option is false" do
         session.driver.options[:respect_data_method] = false
         session.visit "/with_html"
         session.click_link "A link with data-method"
-        session.html.should include('Not deleted')
+        expect(session.html).to include('Not deleted')
       end
 
       it "should use data-method if available even if it's capitalized" do
         session.driver.options[:respect_data_method] = true
         session.visit "/with_html"
         session.click_link "A link with capitalized data-method"
-        session.html.should include('The requested object was deleted')
+        expect(session.html).to include('The requested object was deleted')
       end
 
       after do
@@ -74,7 +74,7 @@ describe Capybara::Session do
         it "should submit an empty form-data section if no file is submitted" do
           session.visit("/form")
           session.click_button("Upload Empty")
-          session.html.should include('Successfully ignored empty file field.')
+          expect(session.html).to include('Successfully ignored empty file field.')
         end
       end
     end
@@ -82,31 +82,31 @@ describe Capybara::Session do
     it "should use the last remote url when following relative links" do
       session.visit("#{remote_test_url}/relative_link_to_host")
       session.click_link "host"
-      session.body.should include("Current host is #{remote_test_url}/request_info/host, method get")
+      expect(session.body).to include("Current host is #{remote_test_url}/request_info/host, method get")
     end
 
     it "should use the last remote url when submitting a form with a relative action" do
       session.visit("#{remote_test_url}/form_with_relative_action_to_host")
       session.click_button "submit"
-      session.body.should include("Current host is #{remote_test_url}/request_info/host, method post")
+      expect(session.body).to include("Current host is #{remote_test_url}/request_info/host, method post")
     end
 
     it "should use the last url when submitting a form with no action" do
       session.visit("#{remote_test_url}/request_info/form_with_no_action")
       session.click_button "submit"
-      session.body.should include("Current host is #{remote_test_url}/request_info/form_with_no_action, method post")
+      expect(session.body).to include("Current host is #{remote_test_url}/request_info/form_with_no_action, method post")
     end
 
     it "should send correct user agent" do
       session.visit("#{remote_test_url}/request_info/user_agent")
-      session.body.should include("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_0) AppleWebKit/535.2 (KHTML, like Gecko) Chrome/15.0.853.0 Safari/535.2")
+      expect(session.body).to include("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_0) AppleWebKit/535.2 (KHTML, like Gecko) Chrome/15.0.853.0 Safari/535.2")
     end
 
     context 'form referer when switching from local to remote' do
       it 'sends the referer' do
         session.visit "/form_posts_to/#{remote_test_url}/get_referer"
         session.click_button 'submit'
-        session.body.should include 'Got referer'
+        expect(session.body).to include 'Got referer'
       end
     end
   end

--- a/spec/session/remote_mechanize_spec.rb
+++ b/spec/session/remote_mechanize_spec.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module TestSessions
-  Mechanize = Capybara::Session.new(:mechanize, TestApp)
+  RemoteMechanize = Capybara::Session.new(:mechanize, TestApp)
 end
 
-shared_context "remote tests" do
+shared_context 'remote tests' do
   before do
     Capybara.app_host = remote_test_url
   end
@@ -14,21 +16,21 @@ shared_context "remote tests" do
   end
 end
 
-session_describe = Capybara::SpecHelper.run_specs TestSessions::Mechanize, "Mechanize", :capybara_skip => [
-  :js,
-  :screenshot,
-  :frames,
-  :windows,
-  :server,
-  :hover,
-  :modals,
-  :about_scheme,
-  :send_keys,
-  :css,
-  :download
+session_describe = Capybara::SpecHelper.run_specs TestSessions::RemoteMechanize, 'RemoteMechanize', capybara_skip: %i[
+  js
+  screenshot
+  frames
+  windows
+  server
+  hover
+  modals
+  about_scheme
+  send_keys
+  css
+  download
 ]
 
-session_describe.include_context("remote tests")
+session_describe.include_context('remote tests')
 
 # We disable additional tests because we don't provide a server, but do test external URls
 disabler = DisableExternalTests.new
@@ -47,36 +49,36 @@ describe Capybara::Session do
     let(:session) { Capybara::Session.new(:mechanize, ExtendedTestApp) }
 
     describe '#driver' do
-      it "should be a mechanize driver" do
+      it 'should be a mechanize driver' do
         expect(session.driver).to be_an_instance_of(Capybara::Mechanize::Driver)
       end
     end
 
     describe '#mode' do
-      it "should remember the mode" do
+      it 'should remember the mode' do
         expect(session.mode).to eq(:mechanize)
       end
     end
 
     describe '#click_link' do
-      it "should use data-method if option is true" do
+      it 'should use data-method if option is true' do
         session.driver.options[:respect_data_method] = true
-        session.visit "/with_html"
-        session.click_link "A link with data-method"
+        session.visit '/with_html'
+        session.click_link 'A link with data-method'
         expect(session.html).to include('The requested object was deleted')
       end
 
-      it "should not use data-method if option is false" do
+      it 'should not use data-method if option is false' do
         session.driver.options[:respect_data_method] = false
-        session.visit "/with_html"
-        session.click_link "A link with data-method"
+        session.visit '/with_html'
+        session.click_link 'A link with data-method'
         expect(session.html).to include('Not deleted')
       end
 
       it "should use data-method if available even if it's capitalized" do
         session.driver.options[:respect_data_method] = true
-        session.visit "/with_html"
-        session.click_link "A link with capitalized data-method"
+        session.visit '/with_html'
+        session.click_link 'A link with capitalized data-method'
         expect(session.html).to include('The requested object was deleted')
       end
 
@@ -85,26 +87,26 @@ describe Capybara::Session do
       end
     end
 
-    describe "#attach_file" do
-      context "with multipart form" do
-        it "should submit an empty form-data section if no file is submitted" do
-          session.visit("/form")
-          session.click_button("Upload Empty")
+    describe '#attach_file' do
+      context 'with multipart form' do
+        it 'should submit an empty form-data section if no file is submitted' do
+          session.visit('/form')
+          session.click_button('Upload Empty')
           expect(session.html).to include('Successfully ignored empty file field.')
         end
       end
     end
 
-    context "remote app in a sub-path" do
-      it "follows relative link correctly" do
-        session.visit "/subsite/relative_link_to_host"
-        session.click_link "host"
+    context 'remote app in a sub-path' do
+      it 'follows relative link correctly' do
+        session.visit '/subsite/relative_link_to_host'
+        session.click_link 'host'
         expect(session.body).to include('request_info2/host')
       end
 
-      it "follows local link correctly" do
-        session.visit "/subsite/local_link_to_host"
-        session.click_link "host"
+      it 'follows local link correctly' do
+        session.visit '/subsite/local_link_to_host'
+        session.click_link 'host'
         expect(session.body).to include('request_info2/host')
       end
     end

--- a/spec/session/remote_mechanize_spec.rb
+++ b/spec/session/remote_mechanize_spec.rb
@@ -48,13 +48,13 @@ describe Capybara::Session do
 
     describe '#driver' do
       it "should be a mechanize driver" do
-        session.driver.should be_an_instance_of(Capybara::Mechanize::Driver)
+        expect(session.driver).to be_an_instance_of(Capybara::Mechanize::Driver)
       end
     end
 
     describe '#mode' do
       it "should remember the mode" do
-        session.mode.should == :mechanize
+        expect(session.mode).to eq(:mechanize)
       end
     end
 
@@ -63,21 +63,21 @@ describe Capybara::Session do
         session.driver.options[:respect_data_method] = true
         session.visit "/with_html"
         session.click_link "A link with data-method"
-        session.html.should include('The requested object was deleted')
+        expect(session.html).to include('The requested object was deleted')
       end
 
       it "should not use data-method if option is false" do
         session.driver.options[:respect_data_method] = false
         session.visit "/with_html"
         session.click_link "A link with data-method"
-        session.html.should include('Not deleted')
+        expect(session.html).to include('Not deleted')
       end
 
       it "should use data-method if available even if it's capitalized" do
         session.driver.options[:respect_data_method] = true
         session.visit "/with_html"
         session.click_link "A link with capitalized data-method"
-        session.html.should include('The requested object was deleted')
+        expect(session.html).to include('The requested object was deleted')
       end
 
       after do
@@ -90,7 +90,7 @@ describe Capybara::Session do
         it "should submit an empty form-data section if no file is submitted" do
           session.visit("/form")
           session.click_button("Upload Empty")
-          session.html.should include('Successfully ignored empty file field.')
+          expect(session.html).to include('Successfully ignored empty file field.')
         end
       end
     end
@@ -99,13 +99,13 @@ describe Capybara::Session do
       it "follows relative link correctly" do
         session.visit "/subsite/relative_link_to_host"
         session.click_link "host"
-        session.body.should include('request_info2/host')
+        expect(session.body).to include('request_info2/host')
       end
 
       it "follows local link correctly" do
         session.visit "/subsite/local_link_to_host"
         session.click_link "host"
-        session.body.should include('request_info2/host')
+        expect(session.body).to include('request_info2/host')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'capybara/spec/spec_helper'
 require 'capybara/mechanize'
 require 'capybara/spec/extended_test_app'
@@ -9,9 +11,8 @@ $LOAD_PATH << File.join(PROJECT_ROOT, 'lib')
 Dir[File.join(PROJECT_ROOT, 'spec', 'support', '**', '*.rb')].each { |file| require(file) }
 
 RSpec.configure do |config|
-  config.filter_run :focus => true unless ENV['CI']
+  config.filter_run focus: true unless ENV['CI']
   config.run_all_when_everything_filtered = true
-  config.treat_symbols_as_metadata_keys_with_true_values = true if RSpec::Version::STRING =~ /^2\./
 
   # Used with DisableExternalTests
   config.filter_run_excluding :external_test_disabled
@@ -26,8 +27,7 @@ RSpec.configure do |config|
 
   Capybara::SpecHelper.configure(config)
 
-  config.order = "random"
+  config.order = 'random'
 
   CAPYBARA_DEFAULT_HOST = Capybara.default_host
 end
-

--- a/spec/support/disable_external_tests.rb
+++ b/spec/support/disable_external_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DisableExternalTests
   attr_accessor :tests_to_disable
 
@@ -8,13 +10,12 @@ class DisableExternalTests
       example_description = to_disable.pop
 
       to_disable.each do |description|
-        example_group = example_group.children.find{ |g| g.description == description }
+        example_group = example_group.children.find { |g| g.description == description }
       end
 
-      example = example_group.examples.find{ |e| e.description == example_description }
+      example = example_group.examples.find { |e| e.description == example_description }
 
       example.metadata[:external_test_disabled] = true unless example.nil?
     end
-
   end
 end

--- a/spec/support/extended_test_app_setup.rb
+++ b/spec/support/extended_test_app_setup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This class works around some weirdness with Capybara's test suite and sinatra's behavior.
 # We need to make sure that sinatra uses TestApp for at least one request before the Capybara session
 # specs run.  Without this we get errors from sinatra trying to handle requests with TestApp.clone

--- a/spec/support/remote_test_url.rb
+++ b/spec/support/remote_test_url.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RemoteTestUrl
   def remote_test_url
     ExtendedTestAppSetup.new.boot.remote_test_url


### PR DESCRIPTION
This builds on PR #64, Updates to the latest RSpec, switches to the `expect` syntax, moves to currently supported rubies only (2.3+), and fixes up a lot of the style issues rubocop flags.