### PR TITLE
Fixes for Capybara 3, Ruby 2-3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ before_install:
   - gem --version
   - bundle --version
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.6
+  - 2.7
+  - 3.0
+  - 3.1
   - jruby
   - ruby-head
 gemfile:

--- a/capybara-mechanize.gemspec
+++ b/capybara-mechanize.gemspec
@@ -6,7 +6,7 @@ require 'capybara/mechanize/version'
 Gem::Specification.new do |s|
   s.name = 'capybara-mechanize'
   s.version = Capybara::Mechanize::VERSION
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.6.0'
 
   s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
   s.authors = ['Jeroen van Dijk']
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.rubygems_version = '1.3.7'
 
-  s.add_runtime_dependency('capybara', ['>= 2.4.4', '< 4'])
+  s.add_runtime_dependency('capybara', ['>= 3.0.0', '< 4'])
   s.add_runtime_dependency('mechanize', ['~> 2.7.0'])
 
   s.add_development_dependency('launchy', ['>= 2.0.4'])

--- a/lib/capybara/mechanize/browser.rb
+++ b/lib/capybara/mechanize/browser.rb
@@ -154,7 +154,7 @@ class Capybara::Mechanize::Browser < Capybara::RackTest::Browser
     if errored_remote_response
       ResponseProxy.new(errored_remote_response)
     elsif @agent.current_page
-      ResponseProxy.new(@agent.current_page)
+      ResponseProxy.new(@agent.current_page, current_fragment: @current_fragment)
     end
   end
 
@@ -169,12 +169,15 @@ class Capybara::Mechanize::Browser < Capybara::RackTest::Browser
 
     attr_reader :page
 
-    def initialize(page)
+    def initialize(page, current_fragment: nil)
       @page = page
+      @current_fragment = current_fragment
     end
 
     def current_url
-      page.uri.to_s
+      uri = page.uri.dup
+      uri.fragment = @current_fragment if @current_fragment
+      uri.to_s
     end
 
     def headers

--- a/lib/capybara/mechanize/node.rb
+++ b/lib/capybara/mechanize/node.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Capybara::Mechanize::Node < Capybara::RackTest::Node
-  def click(keys = [], offset = {})
-    raise ArgumentError, 'The mechanize driver does not support click options' unless keys.empty? && offset.empty?
+  def click(keys = [], **options)
+    raise ArgumentError, 'The mechanize driver does not support click options' unless keys.empty? && options.empty?
 
     submits = respond_to?(:submits?) ? submits? :
       ((tag_name == 'input' and %w[submit image].include?(type)) or

--- a/lib/capybara/mechanize/version.rb
+++ b/lib/capybara/mechanize/version.rb
@@ -2,6 +2,6 @@
 
 module Capybara
   module Mechanize
-    VERSION = '1.11.0'
+    VERSION = '1.12.0'
   end
 end

--- a/lib/capybara/spec/extended_test_app.rb
+++ b/lib/capybara/spec/extended_test_app.rb
@@ -70,6 +70,8 @@ class ExtendedTestApp < TestApp
     request.referer.nil? ? 'No referer' : "Got referer: #{request.referer}"
   end
 
+  @form_post_count = 0
+
   private
 
   def current_request_info

--- a/spec/session/mechanize_spec.rb
+++ b/spec/session/mechanize_spec.rb
@@ -6,19 +6,31 @@ module TestSessions
   Mechanize = Capybara::Session.new(:mechanize, TestApp)
 end
 
-Capybara::SpecHelper.run_specs TestSessions::Mechanize, 'Mechanize', capybara_skip: %i[
-  js
-  screenshot
-  frames
-  windows
-  server
-  hover
-  modals
+skipped_tests = %i[
   about_scheme
-  send_keys
+  active_element
   css
   download
+  frames
+  hover
+  html_validation
+  js
+  modals
+  screenshot
+  scroll
+  send_keys
+  server
+  shadow_dom
+  spatial
+  windows
 ]
+
+Capybara::SpecHelper.run_specs(TestSessions::Mechanize, 'Mechanize', capybara_skip: skipped_tests) do |example|
+  case example.metadata[:full_description]
+  when /has_css\? should support case insensitive :class and :id options/
+    skip "Nokogiri doesn't support case insensitive CSS attribute matchers"
+  end
+end
 
 describe Capybara::Session do
   context 'with mechanize driver' do

--- a/spec/session/remote_mechanize_spec.rb
+++ b/spec/session/remote_mechanize_spec.rb
@@ -16,31 +16,31 @@ shared_context 'remote tests' do
   end
 end
 
-session_describe = Capybara::SpecHelper.run_specs TestSessions::RemoteMechanize, 'RemoteMechanize', capybara_skip: %i[
-  js
-  screenshot
-  frames
-  windows
-  server
-  hover
-  modals
+skipped_tests = %i[
   about_scheme
-  send_keys
+  active_element
   css
   download
+  frames
+  hover
+  html_validation
+  js
+  modals
+  screenshot
+  scroll
+  send_keys
+  server
+  shadow_dom
+  spatial
+  windows
 ]
 
-session_describe.include_context('remote tests')
-
-# We disable additional tests because we don't provide a server, but do test external URls
-disabler = DisableExternalTests.new
-disabler.tests_to_disable = [
-  ['#visit', 'when Capybara.always_include_port is true', 'should fetch a response from the driver with an absolute url without a port'],
-  ['#has_current_path?', 'should compare the full url if url: true is used'],
-  ['#reset_session!', 'raises any errors caught inside the server'],
-  ['#reset_session!', 'raises any standard errors caught inside the server']
-]
-disabler.disable(session_describe)
+Capybara::SpecHelper.run_specs(TestSessions::RemoteMechanize, 'RemoteMechanize', capybara_skip: skipped_tests) do |example|
+  case example.metadata[:full_description]
+  when /has_css\? should support case insensitive :class and :id options/
+    skip "Nokogiri doesn't support case insensitive CSS attribute matchers"
+  end
+end
 
 describe Capybara::Session do
   context 'with remote mechanize driver' do


### PR DESCRIPTION
Hi, some updates I needed to run on Capybara 3 with Ruby 2.7 - 3.1.

```
ruby 3.1.1 $ bundle exec rspec

...

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Capybara::Session RemoteMechanize #has_css? should support case insensitive :class and :id options
     # Nokogiri doesn't support case insensitive CSS attribute matchers
     # /Users/greg/.asdf/installs/ruby/3.1.1/lib/ruby/gems/3.1.0/gems/capybara-3.36.0/lib/capybara/spec/session/has_css_spec.rb:69

  2) Capybara::Session Mechanize #has_css? should support case insensitive :class and :id options
     # Nokogiri doesn't support case insensitive CSS attribute matchers
     # /Users/greg/.asdf/installs/ruby/3.1.1/lib/ruby/gems/3.1.0/gems/capybara-3.36.0/lib/capybara/spec/session/has_css_spec.rb:69


Finished in 58.43 seconds (files took 1.01 seconds to load)
2255 examples, 0 failures, 2 pending

Randomized with seed 54201
```